### PR TITLE
Don't use instance variables to check expectations

### DIFF
--- a/lib/less_interactions/interaction.rb
+++ b/lib/less_interactions/interaction.rb
@@ -23,7 +23,7 @@ module Less
     def self.run(options = {})
       raise InvalidInteractionError, "Every interaction must be initialized with an options hash" unless options.is_a?(Hash)
       me = new(options)
-      raise MissingParameterError unless me.send :expectations_met?
+      raise MissingParameterError unless expectations_met_for?(options)
       me.run
     end
 
@@ -50,12 +50,12 @@ module Less
       expectations[parameter] = options
     end
 
-    def expectations_met?
-      self.class.expectations.each do |param, param_options|
+    def self.expectations_met_for?(params)
+      self.expectations.each do |param, param_options|
       	if param_options[:allow_nil]
-      	  raise MissingParameterError, "Parameter not passed   :#{param.to_s}" unless instance_variable_defined? "@#{param}"
+         raise MissingParameterError, "Parameter not passed   :#{param.to_s}" unless params.keys.member?(param)
       	else
-      	  raise MissingParameterError, "Paramter empty   :#{param.to_s}" if instance_variable_get("@#{param}").nil?
+         raise MissingParameterError, "Paramter empty   :#{param.to_s}" if params[param] == nil
       	end
       end
     end

--- a/test/interaction_test.rb
+++ b/test/interaction_test.rb
@@ -78,19 +78,4 @@ class InteractionTest < Test::Unit::TestCase
     assert_equal 1, i.instance_variable_get(:@a)
     assert_equal 2, i.instance_variable_get(:@b)
   end
-  
-  should "be able to fake out expects" do
-    class X < Less::Interaction
-      expects :object
-      def initialize params
-        super :object => params[:object_id].to_s #or a finder or something instead of to_s
-      end
-      def run; self; end #return self just so I can test the value
-    end
-    assert_nothing_raised do
-      x = X.run( :object_id => 1)
-      assert_equal "1", x.instance_variable_get(:@object)
-    end
-  end
-  
 end


### PR DESCRIPTION
Use the params passed into the interaction instead. Otherwise it is
impossible to define initializers that don't use super to inherit
the default behavior (or define all the params as instance variables, 
even without using them). 

If you call a finder on a single object, that will raise anyway.